### PR TITLE
upgrade react native uuid to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5269,14 +5269,6 @@
         }
       }
     },
-    "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5312,12 +5304,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-native-uuid": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-1.4.9.tgz",
-      "integrity": "sha1-pSZ0L4/d/mQUUAZVISyo0QnEAik=",
-      "requires": {
-        "randombytes": "^2.0.3"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-2.0.1.tgz",
+      "integrity": "sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g=="
     },
     "react-proxy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/smaxtec/react-native-queue#readme",
   "dependencies": {
     "promise-reflect": "^1.1.0",
-    "react-native-uuid": "^1.4.9",
+    "react-native-uuid": "^2.0.1",
     "realm": "5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
@flowolf
Updated react-native-uuid from 1.4.9 to 2.0.1 to get rid of the warning `[SECURITY] node-uuid: crypto not usable, falling back to insecure Math.random()` in the app

